### PR TITLE
Search for similar changes in pull request

### DIFF
--- a/packages/mui-material/src/Chip/Chip.js
+++ b/packages/mui-material/src/Chip/Chip.js
@@ -519,11 +519,11 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
       },
       onKeyDown: (event) => {
         handlers.onKeyDown?.(event);
-        handleKeyDown?.(event);
+        handleKeyDown(event);
       },
       onKeyUp: (event) => {
         handlers.onKeyUp?.(event);
-        handleKeyUp?.(event);
+        handleKeyUp(event);
       },
     }),
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What

Removes unnecessary optional chaining from `handleKeyDown` and `handleKeyUp` in the `Chip` component.

### Why

These internal event handler functions (`handleKeyDown`, `handleKeyUp`) are always defined within the component's scope. Therefore, the optional chaining (`?.`) is redundant and can be safely removed, aligning with the cleanup pattern established in PR #46752.

---
[Slack Thread](https://fountane.slack.com/archives/D0923D35JG3/p1755495426176369?thread_ts=1755495426.176369&cid=D0923D35JG3)

<a href="https://cursor.com/background-agent?bcId=bc-34926e54-bf79-48ce-a57f-bcd919e18ec1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34926e54-bf79-48ce-a57f-bcd919e18ec1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

